### PR TITLE
fix: 将默认的Serial串口重定向从UART2修改为UART1，更符合直觉

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -1,5 +1,5 @@
 name=Air MCU
-version=0.2.0
+version=0.4.0
 
 ## compiler variables 编译器的路径
 compiler.path={runtime.tools.xpack-arm-none-eabi-gcc.path}/bin/

--- a/variants/AIR001/AIR001_DEV/variant_generic.h
+++ b/variants/AIR001/AIR001_DEV/variant_generic.h
@@ -122,7 +122,7 @@
 
 // UART Definitions
 #ifndef SERIAL_UART_INSTANCE
-  #define SERIAL_UART_INSTANCE  2
+  #define SERIAL_UART_INSTANCE  1
 #endif
 
 // Default pin used for generic 'Serial' instance

--- a/variants/AIR001/AirM2M_Air001_Board/variant_generic.h
+++ b/variants/AIR001/AirM2M_Air001_Board/variant_generic.h
@@ -72,7 +72,7 @@
 
 // On-board LED pin number
 #ifndef LED_BUILTIN
-  #define LED_BUILTIN           PNUM_NOT_DEFINED
+  #define LED_BUILTIN           PB1
 #endif
 
 // On-board user button
@@ -122,7 +122,7 @@
 
 // UART Definitions
 #ifndef SERIAL_UART_INSTANCE
-  #define SERIAL_UART_INSTANCE  2
+  #define SERIAL_UART_INSTANCE  1
 #endif
 
 // Default pin used for generic 'Serial' instance

--- a/variants/AIR32F103/F103CB/variant_generic.h
+++ b/variants/AIR32F103/F103CB/variant_generic.h
@@ -132,7 +132,7 @@
 
 // UART Definitions
 #ifndef SERIAL_UART_INSTANCE
-  #define SERIAL_UART_INSTANCE  2
+  #define SERIAL_UART_INSTANCE  1
 #endif
 
 // Default pin used for generic 'Serial' instance


### PR DESCRIPTION
请注意，这是一个破坏性的更新，更新之后一些代码可能会无法通过编译或者工作不正常