### PR TITLE
修复UART模块的复用问题

### DIFF
--- a/cores/AirMCU/HardwareSerial.cpp
+++ b/cores/AirMCU/HardwareSerial.cpp
@@ -26,97 +26,101 @@
 #include "Arduino.h"
 #include "HardwareSerial.h"
 
+std::bitset<static_cast<int>(UartId::count)> HardwareSerial::_serialsInUse;
+
 #if defined(HAL_UART_MODULE_ENABLED) && !defined(HAL_UART_MODULE_ONLY)
-#if defined(HAVE_HWSERIAL1) || defined(HAVE_HWSERIAL2) || defined(HAVE_HWSERIAL3) ||\
-  defined(HAVE_HWSERIAL4) || defined(HAVE_HWSERIAL5) || defined(HAVE_HWSERIAL6) ||\
-  defined(HAVE_HWSERIAL7) || defined(HAVE_HWSERIAL8) || defined(HAVE_HWSERIAL9) ||\
-  defined(HAVE_HWSERIAL10) || defined(HAVE_HWSERIALLP1) || defined(HAVE_HWSERIALLP2)
-  // SerialEvent functions are weak, so when the user doesn't define them,
-  // the linker just sets their address to 0 (which is checked below).
-  #if defined(HAVE_HWSERIAL1)
-    HardwareSerial Serial1(USART1);
-    void serialEvent1() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL1) || defined(HAVE_HWSERIAL2) || defined(HAVE_HWSERIAL3) || \
+    defined(HAVE_HWSERIAL4) || defined(HAVE_HWSERIAL5) || defined(HAVE_HWSERIAL6) || \
+    defined(HAVE_HWSERIAL7) || defined(HAVE_HWSERIAL8) || defined(HAVE_HWSERIAL9) || \
+    defined(HAVE_HWSERIAL10) || defined(HAVE_HWSERIALLP1) || defined(HAVE_HWSERIALLP2)
+// SerialEvent functions are weak, so when the user doesn't define them,
+// the linker just sets their address to 0 (which is checked below).
+#if defined(HAVE_HWSERIAL1)
+HardwareSerial Serial1(USART1);
+void serialEvent1() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL2)
-    HardwareSerial Serial2(USART2);
-    void serialEvent2() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL2)
+HardwareSerial Serial2(USART2);
+void serialEvent2() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL3)
-    HardwareSerial Serial3(USART3);
-    void serialEvent3() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL3)
+HardwareSerial Serial3(USART3);
+void serialEvent3() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL4)
-    #if defined(USART4)
-      HardwareSerial Serial4(USART4);
-    #else
-      HardwareSerial Serial4(UART4);
-    #endif
-    void serialEvent4() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL4)
+#if defined(USART4)
+HardwareSerial Serial4(USART4);
+#else
+HardwareSerial Serial4(UART4);
+#endif
+void serialEvent4() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL5)
-    #if defined(USART5)
-      HardwareSerial Serial5(USART5);
-    #else
-      HardwareSerial Serial5(UART5);
-    #endif
-    void serialEvent5() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL5)
+#if defined(USART5)
+HardwareSerial Serial5(USART5);
+#else
+HardwareSerial Serial5(UART5);
+#endif
+void serialEvent5() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL6)
-    HardwareSerial Serial6(USART6);
-    void serialEvent6() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL6)
+HardwareSerial Serial6(USART6);
+void serialEvent6() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL7)
-    #if defined(USART7)
-      HardwareSerial Serial7(USART7);
-    #else
-      HardwareSerial Serial7(UART7);
-    #endif
-    void serialEvent7() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL7)
+#if defined(USART7)
+HardwareSerial Serial7(USART7);
+#else
+HardwareSerial Serial7(UART7);
+#endif
+void serialEvent7() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL8)
-    #if defined(USART8)
-      HardwareSerial Serial8(USART8);
-    #else
-      HardwareSerial Serial8(UART8);
-    #endif
-    void serialEvent8() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL8)
+#if defined(USART8)
+HardwareSerial Serial8(USART8);
+#else
+HardwareSerial Serial8(UART8);
+#endif
+void serialEvent8() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL9)
-    HardwareSerial Serial9(UART9);
-    void serialEvent9() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL9)
+HardwareSerial Serial9(UART9);
+void serialEvent9() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIAL10)
-    #if defined(USART10)
-      HardwareSerial Serial10(USART10);
-    #else
-      HardwareSerial Serial10(UART10);
-    #endif
-    void serialEvent10() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIAL10)
+#if defined(USART10)
+HardwareSerial Serial10(USART10);
+#else
+HardwareSerial Serial10(UART10);
+#endif
+void serialEvent10() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIALLP1)
-    HardwareSerial SerialLP1(LPUART1);
-    void serialEventLP1() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIALLP1)
+HardwareSerial SerialLP1(LPUART1);
+void serialEventLP1() __attribute__((weak));
+#endif
 
-  #if defined(HAVE_HWSERIALLP2)
-    HardwareSerial SerialLP2(LPUART2);
-    void serialEventLP2() __attribute__((weak));
-  #endif
+#if defined(HAVE_HWSERIALLP2)
+HardwareSerial SerialLP2(LPUART2);
+void serialEventLP2() __attribute__((weak));
+#endif
+
 #endif // HAVE_HWSERIALx
 
 // Constructors ////////////////////////////////////////////////////////////////
 HardwareSerial::HardwareSerial(uint32_t _rx, uint32_t _tx, uint32_t _rts, uint32_t _cts)
 {
+  // this._serialsInUse
   init(digitalPinToPinName(_rx), digitalPinToPinName(_tx), digitalPinToPinName(_rts), digitalPinToPinName(_cts));
 }
 
@@ -132,156 +136,180 @@ HardwareSerial::HardwareSerial(void *peripheral, HalfDuplexMode_t halfDuplex)
   // If Serial is defined in variant set
   // the Rx/Tx pins for com port if defined
 #if defined(Serial) && defined(PIN_SERIAL_TX)
-  if ((void *)this == (void *)&Serial) {
+  if ((void *)this == (void *)&Serial)
+  {
 #if defined(PIN_SERIAL_RX)
     setRx(PIN_SERIAL_RX);
 #endif
     setTx(PIN_SERIAL_TX);
-  } else
+  }
+  else
 #endif
 #if defined(PIN_SERIAL1_TX) && defined(USART1_BASE)
-    if (peripheral == USART1) {
+      if (peripheral == USART1)
+  {
 #if defined(PIN_SERIAL1_RX)
-      setRx(PIN_SERIAL1_RX);
+    setRx(PIN_SERIAL1_RX);
 #endif
-      setTx(PIN_SERIAL1_TX);
-    } else
+    setTx(PIN_SERIAL1_TX);
+  }
+  else
 #endif
 #if defined(PIN_SERIAL2_TX) && defined(USART2_BASE)
-      if (peripheral == USART2) {
+      if (peripheral == USART2)
+  {
 #if defined(PIN_SERIAL2_RX)
-        setRx(PIN_SERIAL2_RX);
+    setRx(PIN_SERIAL2_RX);
 #endif
-        setTx(PIN_SERIAL2_TX);
-      } else
+    setTx(PIN_SERIAL2_TX);
+  }
+  else
 #endif
 #if defined(PIN_SERIAL3_TX) && defined(USART3_BASE)
-        if (peripheral == USART3) {
+      if (peripheral == USART3)
+  {
 #if defined(PIN_SERIAL3_RX)
-          setRx(PIN_SERIAL3_RX);
+    setRx(PIN_SERIAL3_RX);
 #endif
-          setTx(PIN_SERIAL3_TX);
-        } else
+    setTx(PIN_SERIAL3_TX);
+  }
+  else
 #endif
-#if defined(PIN_SERIAL4_TX) &&\
-   (defined(USART4_BASE) || defined(UART4_BASE))
+#if defined(PIN_SERIAL4_TX) && \
+    (defined(USART4_BASE) || defined(UART4_BASE))
 #if defined(USART4_BASE)
-          if (peripheral == USART4)
+      if (peripheral == USART4)
 #elif defined(UART4_BASE)
-          if (peripheral == UART4)
+      if (peripheral == UART4)
 #endif
-          {
+  {
 #if defined(PIN_SERIAL4_RX)
-            setRx(PIN_SERIAL4_RX);
+    setRx(PIN_SERIAL4_RX);
 #endif
-            setTx(PIN_SERIAL4_TX);
-          } else
+    setTx(PIN_SERIAL4_TX);
+  }
+  else
 #endif
-#if defined(PIN_SERIAL5_TX) &&\
-   (defined(USART5_BASE) || defined(UART5_BASE))
+#if defined(PIN_SERIAL5_TX) && \
+    (defined(USART5_BASE) || defined(UART5_BASE))
 #if defined(USART5_BASE)
-            if (peripheral == USART5)
+      if (peripheral == USART5)
 #elif defined(UART5_BASE)
-            if (peripheral == UART5)
+      if (peripheral == UART5)
 #endif
-            {
+  {
 #if defined(PIN_SERIAL5_RX)
-              setRx(PIN_SERIAL5_RX);
+    setRx(PIN_SERIAL5_RX);
 #endif
-              setTx(PIN_SERIAL5_TX);
-            } else
+    setTx(PIN_SERIAL5_TX);
+  }
+  else
 #endif
 #if defined(PIN_SERIAL6_TX) && defined(USART6_BASE)
-              if (peripheral == USART6) {
+      if (peripheral == USART6)
+  {
 #if defined(PIN_SERIAL6_RX)
-                setRx(PIN_SERIAL6_RX);
+    setRx(PIN_SERIAL6_RX);
 #endif
-                setTx(PIN_SERIAL6_TX);
-              } else
+    setTx(PIN_SERIAL6_TX);
+  }
+  else
 #endif
-#if defined(PIN_SERIAL7_TX) &&\
-   (defined(USART7_BASE) || defined(UART7_BASE))
+#if defined(PIN_SERIAL7_TX) && \
+    (defined(USART7_BASE) || defined(UART7_BASE))
 #if defined(USART7_BASE)
-                if (peripheral == USART7)
+      if (peripheral == USART7)
 #elif defined(UART7_BASE)
-                if (peripheral == UART7)
+      if (peripheral == UART7)
 #endif
-                {
+  {
 #if defined(PIN_SERIAL7_RX)
-                  setRx(PIN_SERIAL7_RX);
+    setRx(PIN_SERIAL7_RX);
 #endif
-                  setTx(PIN_SERIAL7_TX);
-                } else
+    setTx(PIN_SERIAL7_TX);
+  }
+  else
 #endif
-#if defined(PIN_SERIAL8_TX) &&\
-   (defined(USART8_BASE) || defined(UART8_BASE))
+#if defined(PIN_SERIAL8_TX) && \
+    (defined(USART8_BASE) || defined(UART8_BASE))
 #if defined(USART8_BASE)
-                  if (peripheral == USART8)
+      if (peripheral == USART8)
 #elif defined(UART8_BASE)
-                  if (peripheral == UART8)
+      if (peripheral == UART8)
 #endif
-                  {
+  {
 #if defined(PIN_SERIAL8_RX)
-                    setRx(PIN_SERIAL8_RX);
+    setRx(PIN_SERIAL8_RX);
 #endif
-                    setTx(PIN_SERIAL8_TX);
-                  } else
+    setTx(PIN_SERIAL8_TX);
+  }
+  else
 #endif
 #if defined(PIN_SERIAL9_TX) && defined(UART9_BASE)
-                    if (peripheral == UART9) {
+      if (peripheral == UART9)
+  {
 #if defined(PIN_SERIAL9_RX)
-                      setRx(PIN_SERIAL9_RX);
+    setRx(PIN_SERIAL9_RX);
 #endif
-                      setTx(PIN_SERIAL9_TX);
-                    } else
+    setTx(PIN_SERIAL9_TX);
+  }
+  else
 #endif
-#if defined(PIN_SERIAL10_TX) &&\
-   (defined(USART10_BASE) || defined(UART10_BASE))
+#if defined(PIN_SERIAL10_TX) && \
+    (defined(USART10_BASE) || defined(UART10_BASE))
 #if defined(USART10_BASE)
-                      if (peripheral == USART10)
+      if (peripheral == USART10)
 #elif defined(UART10_BASE)
-                      if (peripheral == UART10)
+      if (peripheral == UART10)
 #endif
-                      {
+  {
 #if defined(PIN_SERIAL10_RX)
-                        setRx(PIN_SERIAL10_RX);
+    setRx(PIN_SERIAL10_RX);
 #endif
-                        setTx(PIN_SERIAL10_TX);
-                      } else
+    setTx(PIN_SERIAL10_TX);
+  }
+  else
 #endif
 #if defined(PIN_SERIALLP1_TX) && defined(LPUART1_BASE)
-                        if (peripheral == LPUART1) {
+      if (peripheral == LPUART1)
+  {
 #if defined(PIN_SERIALLP1_RX)
-                          setRx(PIN_SERIALLP1_RX);
+    setRx(PIN_SERIALLP1_RX);
 #endif
-                          setTx(PIN_SERIALLP1_TX);
-                        } else
+    setTx(PIN_SERIALLP1_TX);
+  }
+  else
 #endif
 #if defined(PIN_SERIALLP2_TX) && defined(LPUART2_BASE)
-                          if (peripheral == LPUART2) {
+      if (peripheral == LPUART2)
+  {
 #if defined(PIN_SERIALLP2_RX)
-                            setRx(PIN_SERIALLP2_RX);
+    setRx(PIN_SERIALLP2_RX);
 #endif
-                            setTx(PIN_SERIALLP2_TX);
-                          } else
+    setTx(PIN_SERIALLP2_TX);
+  }
+  else
 #endif
 #if defined(PIN_SERIAL_TX)
-                            // If PIN_SERIAL_TX is defined but Serial is mapped on other peripheral
-                            // (usually SerialUSB) use the pins defined for specified peripheral
-                            // instead of the first one found
-                            if ((pinmap_peripheral(digitalPinToPinName(PIN_SERIAL_TX), PinMap_UART_TX) == peripheral)) {
+    // If PIN_SERIAL_TX is defined but Serial is mapped on other peripheral
+    // (usually SerialUSB) use the pins defined for specified peripheral
+    // instead of the first one found
+    if ((pinmap_peripheral(digitalPinToPinName(PIN_SERIAL_TX), PinMap_UART_TX) == peripheral))
+    {
 #if defined(PIN_SERIAL_RX)
-                              setRx(PIN_SERIAL_RX);
+      setRx(PIN_SERIAL_RX);
 #endif
-                              setTx(PIN_SERIAL_TX);
-                            } else
+      setTx(PIN_SERIAL_TX);
+    }
+    else
 #endif
-                            {
-                              // else get the pins of the first peripheral occurrence in PinMap
-                              _serial.pin_rx = pinmap_pin(peripheral, PinMap_UART_RX);
-                              _serial.pin_tx = pinmap_pin(peripheral, PinMap_UART_TX);
-                            }
-  if (halfDuplex == HALF_DUPLEX_ENABLED) {
+    {
+      // else get the pins of the first peripheral occurrence in PinMap
+      _serial.pin_rx = pinmap_pin(peripheral, PinMap_UART_RX);
+      _serial.pin_tx = pinmap_pin(peripheral, PinMap_UART_TX);
+    }
+  if (halfDuplex == HALF_DUPLEX_ENABLED)
+  {
     _serial.pin_rx = NC;
   }
   init(_serial.pin_rx, _serial.pin_tx);
@@ -297,11 +325,102 @@ HardwareSerial::HardwareSerial(PinName _rxtx)
   init(NC, _rxtx);
 }
 
+UartId _findUartId(USART_TypeDef *uart)
+{
+#if defined(USART1_BASE)
+  if (uart == USART1)
+  {
+    return UartId::Usart1;
+  }
+#elif defined(LPUART1_BASE)
+  if (uart == LPUART1)
+  {
+    return UartId::Lpuart1;
+  }
+#elif defined(USART2_BASE)
+  if (uart == USART2)
+  {
+    return UartId::Usart2;
+  }
+#elif defined(LPUART2_BASE)
+  if (uart == LPUART2)
+  {
+    return UartId::Lpuart2;
+  }
+#elif defined(USART3_BASE) || defined(USART3_BASE)
+  if (uart == USART3 || uart == UART3)
+  {
+    return UartId::Usart3;
+  }
+#elif defined(USART4_BASE) || defined(UART4_BASE)
+  if (uart == USART4 || uart == UART4)
+  {
+    return UartId::Usart4;
+  }
+#elif defined(USART5_BASE) || defined(UART5_BASE)
+  if (uart == USART5 || uart == UART5)
+  {
+    return UartId::Usart5;
+  }
+#elif defined(USART6_BASE) || defined(UART6_BASE)
+  if (uart == USART6 || uart == UART6)
+  {
+    return UartId::Usart6;
+  }
+#elif defined(USART7_BASE) || defined(UART7_BASE)
+  if (uart == USART7 || uart == UART7)
+  {
+    return UartId::Usart7;
+  }
+#elif defined(USART8_BASE) || defined(UART8_BASE)
+  if (uart == USART8 || uart == UART8)
+  {
+    return UartId::Usart8;
+  }
+#elif defined(UART9_BASE) || defined(UART9_BASE)
+  if (uart == UART9 || uart == UART9)
+  {
+    return UartId::Uart9;
+  }
+#elif defined(USART10_BASE) || defined(UART10_BASE)
+  if (uart == USART10 || uart == UART10)
+  {
+    return UartId::Usart10;
+  }
+#endif
+  return UartId::count;
+}
+
 void HardwareSerial::init(PinName _rx, PinName _tx, PinName _rts, PinName _cts)
 {
-  if (_rx == _tx) {
+  int count = 0;
+  while (true)
+  {
+    auto _uart = reinterpret_cast<USART_TypeDef *>(pinmap_peripheral_ignore(_tx, PinMap_UART_TX, count));
+    auto uartId = static_cast<int>(_findUartId(_uart));
+    if (_serialsInUse[uartId] == 0) // if serial is in not use
+    {
+      _serialsInUse[uartId] = 1;
+      _serial.uart = _uart;
+      break;
+    }
+    else
+    {
+      count++;
+      if (count >= static_cast<int>(UartId::count))
+      {
+        break;
+      }
+    }
+    
+  }
+
+  if (_rx == _tx)
+  {
     _serial.pin_rx = NC;
-  } else {
+  }
+  else
+  {
     _serial.pin_rx = _rx;
   }
   _serial.pin_tx = _tx;
@@ -332,7 +451,8 @@ void HardwareSerial::_rx_complete_irq(serial_t *obj)
   // No Parity error, read byte and store it in the buffer if there is room
   unsigned char c;
 
-  if (uart_getc(obj, &c) == 0) {
+  if (uart_getc(obj, &c) == 0)
+  {
 
     rx_buffer_index_t i = (unsigned int)(obj->rx_head + 1) % SERIAL_RX_BUFFER_SIZE;
 
@@ -340,7 +460,8 @@ void HardwareSerial::_rx_complete_irq(serial_t *obj)
     // just before the tail (meaning that the head would advance to the
     // current location of the tail), we're about to overflow the buffer
     // and so we don't write the character or advance the head.
-    if (i != obj->rx_tail) {
+    if (i != obj->rx_tail)
+    {
       obj->rx_buff[obj->rx_head] = c;
       obj->rx_head = i;
     }
@@ -356,9 +477,9 @@ int HardwareSerial::_tx_complete_irq(serial_t *obj)
   obj->tx_tail = (obj->tx_tail + obj->tx_size) % SERIAL_TX_BUFFER_SIZE;
 
   // If buffer is not empty (head != tail), send remaining data
-  if (obj->tx_head != obj->tx_tail) {
-    remaining_data = (SERIAL_TX_BUFFER_SIZE + obj->tx_head - obj->tx_tail)
-                     % SERIAL_TX_BUFFER_SIZE;
+  if (obj->tx_head != obj->tx_tail)
+  {
+    remaining_data = (SERIAL_TX_BUFFER_SIZE + obj->tx_head - obj->tx_tail) % SERIAL_TX_BUFFER_SIZE;
     // Limit the next transmission to the buffer end
     // because HAL is not able to manage rollover
     obj->tx_size = min(remaining_data,
@@ -382,53 +503,63 @@ void HardwareSerial::begin(unsigned long baud, byte config)
   _config = config;
 
   // Manage databits
-  switch (config & 0x07) {
-    case 0x02:
-      databits = 6;
-      break;
-    case 0x04:
-      databits = 7;
-      break;
-    case 0x06:
-      databits = 8;
-      break;
-    default:
-      databits = 0;
-      break;
+  switch (config & 0x07)
+  {
+  case 0x02:
+    databits = 6;
+    break;
+  case 0x04:
+    databits = 7;
+    break;
+  case 0x06:
+    databits = 8;
+    break;
+  default:
+    databits = 0;
+    break;
   }
 
-  if ((config & 0x30) == 0x30) {
+  if ((config & 0x30) == 0x30)
+  {
     parity = UART_PARITY_ODD;
     databits++;
-  } else if ((config & 0x20) == 0x20) {
+  }
+  else if ((config & 0x20) == 0x20)
+  {
     parity = UART_PARITY_EVEN;
     databits++;
-  } else {
+  }
+  else
+  {
     parity = UART_PARITY_NONE;
   }
 
-  if ((config & 0x08) == 0x08) {
+  if ((config & 0x08) == 0x08)
+  {
     stopbits = UART_STOPBITS_2;
-  } else {
+  }
+  else
+  {
     stopbits = UART_STOPBITS_1;
   }
 
-  switch (databits) {
+  switch (databits)
+  {
 #ifdef UART_WORDLENGTH_7B
-    case 7:
-      databits = UART_WORDLENGTH_7B;
-      break;
+  case 7:
+    databits = UART_WORDLENGTH_7B;
+    break;
 #endif
-    case 8:
-      databits = UART_WORDLENGTH_8B;
-      break;
-    case 9:
-      databits = UART_WORDLENGTH_9B;
-      break;
-    default:
-    case 0:
-      Error_Handler();
-      break;
+  case 8:
+    databits = UART_WORDLENGTH_8B;
+    break;
+  case 9:
+    databits = UART_WORDLENGTH_9B;
+    break;
+  default:
+  case 0:
+    Error_Handler();
+    break;
   }
 
   uart_init(&_serial, (uint32_t)baud, databits, parity, stopbits);
@@ -454,9 +585,12 @@ int HardwareSerial::available(void)
 
 int HardwareSerial::peek(void)
 {
-  if (_serial.rx_head == _serial.rx_tail) {
+  if (_serial.rx_head == _serial.rx_tail)
+  {
     return -1;
-  } else {
+  }
+  else
+  {
     return _serial.rx_buff[_serial.rx_tail];
   }
 }
@@ -465,9 +599,12 @@ int HardwareSerial::read(void)
 {
   enableHalfDuplexRx();
   // if the head isn't ahead of the tail, we don't have any characters
-  if (_serial.rx_head == _serial.rx_tail) {
+  if (_serial.rx_head == _serial.rx_tail)
+  {
     return -1;
-  } else {
+  }
+  else
+  {
     unsigned char c = _serial.rx_buff[_serial.rx_tail];
     _serial.rx_tail = (rx_buffer_index_t)(_serial.rx_tail + 1) % SERIAL_RX_BUFFER_SIZE;
     return c;
@@ -479,7 +616,8 @@ int HardwareSerial::availableForWrite(void)
   tx_buffer_index_t head = _serial.tx_head;
   tx_buffer_index_t tail = _serial.tx_tail;
 
-  if (head >= tail) {
+  if (head >= tail)
+  {
     return SERIAL_TX_BUFFER_SIZE - 1 - head + tail;
   }
   return tail - head - 1;
@@ -490,11 +628,13 @@ void HardwareSerial::flush()
   // If we have never written a byte, no need to flush. This special
   // case is needed since there is no way to force the TXC (transmit
   // complete) bit to 1 during initialization
-  if (!_written) {
+  if (!_written)
+  {
     return;
   }
 
-  while ((_serial.tx_head != _serial.tx_tail)) {
+  while ((_serial.tx_head != _serial.tx_tail))
+  {
     // nop, the interrupt handler will free up space for us
   }
   // If we get here, nothing is queued anymore (DRIE is disabled) and
@@ -509,8 +649,10 @@ size_t HardwareSerial::write(const uint8_t *buffer, size_t size)
   size_t available_till_buffer_end = SERIAL_TX_BUFFER_SIZE - _serial.tx_head;
 
   _written = true;
-  if (isHalfDuplex()) {
-    if (_rx_enabled) {
+  if (isHalfDuplex())
+  {
+    if (_rx_enabled)
+    {
       _rx_enabled = false;
       uart_enable_tx(&_serial);
     }
@@ -518,13 +660,15 @@ size_t HardwareSerial::write(const uint8_t *buffer, size_t size)
 
   // If the output buffer is full, there's nothing for it other than to
   // wait for the interrupt handler to free space
-  while (!availableForWrite()) {
+  while (!availableForWrite())
+  {
     // nop, the interrupt handler will free up space for us
   }
 
   // HAL doesn't manage rollover, so split transfer till end of TX buffer
   // Also, split transfer according to available space in buffer
-  while ((size > available_till_buffer_end) || (size > available)) {
+  while ((size > available_till_buffer_end) || (size > available))
+  {
     size_intermediate = min(available, available_till_buffer_end);
     write(buffer, size_intermediate);
     size -= size_intermediate;
@@ -534,10 +678,13 @@ size_t HardwareSerial::write(const uint8_t *buffer, size_t size)
   }
 
   // Copy data to buffer. Take into account rollover if necessary.
-  if (_serial.tx_head + size <= SERIAL_TX_BUFFER_SIZE) {
+  if (_serial.tx_head + size <= SERIAL_TX_BUFFER_SIZE)
+  {
     memcpy(&_serial.tx_buff[_serial.tx_head], buffer, size);
     size_intermediate = size;
-  } else {
+  }
+  else
+  {
     // memcpy till end of buffer then continue memcpy from beginning of buffer
     size_intermediate = SERIAL_TX_BUFFER_SIZE - _serial.tx_head;
     memcpy(&_serial.tx_buff[_serial.tx_head], buffer, size_intermediate);
@@ -550,7 +697,8 @@ size_t HardwareSerial::write(const uint8_t *buffer, size_t size)
 
   // Transfer data with HAL only is there is no TX data transfer ongoing
   // otherwise, data transfer will be done asynchronously from callback
-  if (!serial_tx_active(&_serial)) {
+  if (!serial_tx_active(&_serial))
+  {
     // note: tx_size correspond to size of HAL data transfer,
     // not the total amount of data in the buffer.
     // To compute size of data in buffer compare head and tail
@@ -632,11 +780,13 @@ bool HardwareSerial::isHalfDuplex(void) const
 
 void HardwareSerial::enableHalfDuplexRx(void)
 {
-  if (isHalfDuplex()) {
+  if (isHalfDuplex())
+  {
     // In half-duplex mode we have to wait for all TX characters to
     // be transmitted before we can receive data.
     flush();
-    if (!_rx_enabled) {
+    if (!_rx_enabled)
+    {
       _rx_enabled = true;
       uart_enable_rx(&_serial);
     }

--- a/cores/AirMCU/HardwareSerial.h
+++ b/cores/AirMCU/HardwareSerial.h
@@ -28,6 +28,8 @@
 
 #include "Stream.h"
 #include "uart.h"
+#include <bitset>
+#include <vector>
 
 // Define constants and variables for buffering incoming serial data.  We're
 // using a ring buffer (I think), in which head is the index of the location
@@ -41,49 +43,50 @@
 // often work, but occasionally a race condition can occur that makes
 // Serial behave erratically. See https://github.com/arduino/Arduino/issues/2405
 #if !defined(SERIAL_TX_BUFFER_SIZE)
-  #define SERIAL_TX_BUFFER_SIZE 64
+#define SERIAL_TX_BUFFER_SIZE 64
 #endif
 #if !defined(SERIAL_RX_BUFFER_SIZE)
-  #define SERIAL_RX_BUFFER_SIZE 64
+#define SERIAL_RX_BUFFER_SIZE 64
 #endif
-#if (SERIAL_TX_BUFFER_SIZE>256)
-  typedef uint16_t tx_buffer_index_t;
+#if (SERIAL_TX_BUFFER_SIZE > 256)
+typedef uint16_t tx_buffer_index_t;
 #else
-  typedef uint8_t tx_buffer_index_t;
+typedef uint8_t tx_buffer_index_t;
 #endif
-#if  (SERIAL_RX_BUFFER_SIZE>256)
-  typedef uint16_t rx_buffer_index_t;
+#if (SERIAL_RX_BUFFER_SIZE > 256)
+typedef uint16_t rx_buffer_index_t;
 #else
-  typedef uint8_t rx_buffer_index_t;
+typedef uint8_t rx_buffer_index_t;
 #endif
 
 // A bool should be enough for this
 // But it brings an build error due to ambiguous
 // call of overloaded HardwareSerial(int, int)
 // So defining a dedicated type
-typedef enum {
+typedef enum
+{
   HALF_DUPLEX_DISABLED,
   HALF_DUPLEX_ENABLED
 } HalfDuplexMode_t;
 
 // Define config for Serial.begin(baud, config);
 // below configs are not supported by AIR
-//#define SERIAL_5N1 0x00
-//#define SERIAL_5N2 0x08
-//#define SERIAL_5E1 0x20
-//#define SERIAL_5E2 0x28
-//#define SERIAL_5O1 0x30
-//#define SERIAL_5O2 0x38
-//#define SERIAL_6N1 0x02
-//#define SERIAL_6N2 0x0A
+// #define SERIAL_5N1 0x00
+// #define SERIAL_5N2 0x08
+// #define SERIAL_5E1 0x20
+// #define SERIAL_5E2 0x28
+// #define SERIAL_5O1 0x30
+// #define SERIAL_5O2 0x38
+// #define SERIAL_6N1 0x02
+// #define SERIAL_6N2 0x0A
 
 #ifdef UART_WORDLENGTH_7B
-  #define SERIAL_7N1 0x04
-  #define SERIAL_7N2 0x0C
-  #define SERIAL_6E1 0x22
-  #define SERIAL_6E2 0x2A
-  #define SERIAL_6O1 0x32
-  #define SERIAL_6O2 0x3A
+#define SERIAL_7N1 0x04
+#define SERIAL_7N2 0x0C
+#define SERIAL_6E1 0x22
+#define SERIAL_6E2 0x2A
+#define SERIAL_6O1 0x32
+#define SERIAL_6O2 0x3A
 #endif
 #define SERIAL_8N1 0x06
 #define SERIAL_8N2 0x0E
@@ -96,135 +99,181 @@ typedef enum {
 #define SERIAL_7O2 0x3C
 #define SERIAL_8O2 0x3E
 
-class HardwareSerial : public Stream {
-  protected:
-    // Has any byte been written to the UART since begin()
-    bool _written;
+enum class UartId
+{
+#if defined(USART1_BASE)
+  Usart1,
+#endif
+#if defined(USART2_BASE)
+  Usart2,
+#endif
+#if defined(USART3_BASE) || defined(USART3_BASE)
+  Usart3,
+#endif
+#if defined(UART4_BASE) || defined(USART4_BASE)
+  Usart4,
+#endif
+#if defined(UART5_BASE) || defined(USART5_BASE)
+  Usart5,
+#endif
+#if defined(USART6_BASE) || defined(USART6_BASE)
+  Usart6,
+#endif
+#if defined(UART7_BASE) || defined(USART7_BASE)
+  Usart7,
+#endif
+#if defined(UART8_BASE) || defined(USART8_BASE)
+  Usart8,
+#endif
+#if defined(UART9_BASE) || defined(USART9_BASE)
+  Uart9,
+#endif
+#if defined(UART10_BASE) || defined(USART10_BASE)
+  Usart10,
+#endif
+#if defined(LPUART1_BASE)
+  Lpuart1,
+#endif
+#if defined(LPUART2_BASE)
+  Lpuart2,
+#endif
 
-    // Don't put any members after these buffers, since only the first
-    // 32 bytes of this struct can be accessed quickly using the ldd
-    // instruction.
-    unsigned char _rx_buffer[SERIAL_RX_BUFFER_SIZE];
-    unsigned char _tx_buffer[SERIAL_TX_BUFFER_SIZE];
+  count, // Number of UARTs
+};
 
-    serial_t _serial;
+class HardwareSerial : public Stream
+{
+private:
+  static std::bitset<static_cast<int>(UartId::count)> _serialsInUse;
+  
+protected:
+  // Has any byte been written to the UART since begin()
+  bool _written;
 
-  public:
-    HardwareSerial(uint32_t _rx, uint32_t _tx, uint32_t _rts = NUM_DIGITAL_PINS, uint32_t _cts = NUM_DIGITAL_PINS);
-    HardwareSerial(PinName _rx, PinName _tx, PinName _rts = NC, PinName _cts = NC);
-    HardwareSerial(void *peripheral, HalfDuplexMode_t halfDuplex = HALF_DUPLEX_DISABLED);
-    HardwareSerial(uint32_t _rxtx);
-    HardwareSerial(PinName _rxtx);
-    void begin(unsigned long baud)
-    {
-      begin(baud, SERIAL_8N1);
-    }
-    void begin(unsigned long, uint8_t);
-    void end();
-    virtual int available(void);
-    virtual int peek(void);
-    virtual int read(void);
-    int availableForWrite(void);
-    virtual void flush(void);
-    virtual size_t write(uint8_t);
-    inline size_t write(unsigned long n)
-    {
-      return write((uint8_t)n);
-    }
-    inline size_t write(long n)
-    {
-      return write((uint8_t)n);
-    }
-    inline size_t write(unsigned int n)
-    {
-      return write((uint8_t)n);
-    }
-    inline size_t write(int n)
-    {
-      return write((uint8_t)n);
-    }
-    size_t write(const uint8_t *buffer, size_t size);
-    using Print::write; // pull in write(str) from Print
-    operator bool()
-    {
-      return true;
-    }
+  // Don't put any members after these buffers, since only the first
+  // 32 bytes of this struct can be accessed quickly using the ldd
+  // instruction.
+  unsigned char _rx_buffer[SERIAL_RX_BUFFER_SIZE];
+  unsigned char _tx_buffer[SERIAL_TX_BUFFER_SIZE];
 
-    void setRx(uint32_t _rx);
-    void setTx(uint32_t _tx);
-    void setRx(PinName _rx);
-    void setTx(PinName _tx);
+  serial_t _serial;
 
-    // Enable HW flow control on RTS, CTS or both
-    void setRts(uint32_t _rts);
-    void setCts(uint32_t _cts);
-    void setRtsCts(uint32_t _rts, uint32_t _cts);
-    void setRts(PinName _rts);
-    void setCts(PinName _cts);
-    void setRtsCts(PinName _rts, PinName _cts);
+public:
+  HardwareSerial(uint32_t _rx, uint32_t _tx, uint32_t _rts = NUM_DIGITAL_PINS, uint32_t _cts = NUM_DIGITAL_PINS);
+  HardwareSerial(PinName _rx, PinName _tx, PinName _rts = NC, PinName _cts = NC);
+  HardwareSerial(void *peripheral, HalfDuplexMode_t halfDuplex = HALF_DUPLEX_DISABLED);
+  HardwareSerial(uint32_t _rxtx);
+  HardwareSerial(PinName _rxtx);
+  void begin(unsigned long baud)
+  {
+    begin(baud, SERIAL_8N1);
+  }
+  void begin(unsigned long, uint8_t);
+  void end();
+  virtual int available(void);
+  virtual int peek(void);
+  virtual int read(void);
+  int availableForWrite(void);
+  virtual void flush(void);
+  virtual size_t write(uint8_t);
+  inline size_t write(unsigned long n)
+  {
+    return write((uint8_t)n);
+  }
+  inline size_t write(long n)
+  {
+    return write((uint8_t)n);
+  }
+  inline size_t write(unsigned int n)
+  {
+    return write((uint8_t)n);
+  }
+  inline size_t write(int n)
+  {
+    return write((uint8_t)n);
+  }
+  size_t write(const uint8_t *buffer, size_t size);
+  using Print::write; // pull in write(str) from Print
+  operator bool()
+  {
+    return true;
+  }
 
-    // Enable half-duplex mode by setting the Rx pin to NC
-    // This needs to be done before the call to begin()
-    void setHalfDuplex(void);
-    bool isHalfDuplex(void) const;
-    void enableHalfDuplexRx(void);
+  void setRx(uint32_t _rx);
+  void setTx(uint32_t _tx);
+  void setRx(PinName _rx);
+  void setTx(PinName _tx);
 
-    friend class AirLowPower;
+  // Enable HW flow control on RTS, CTS or both
+  void setRts(uint32_t _rts);
+  void setCts(uint32_t _cts);
+  void setRtsCts(uint32_t _rts, uint32_t _cts);
+  void setRts(PinName _rts);
+  void setCts(PinName _cts);
+  void setRtsCts(PinName _rts, PinName _cts);
 
-    // Interrupt handlers
-    static void _rx_complete_irq(serial_t *obj);
-    static int _tx_complete_irq(serial_t *obj);
+  // Enable half-duplex mode by setting the Rx pin to NC
+  // This needs to be done before the call to begin()
+  void setHalfDuplex(void);
+  bool isHalfDuplex(void) const;
+  void enableHalfDuplexRx(void);
+
+  friend class AirLowPower;
+
+  // Interrupt handlers
+  static void _rx_complete_irq(serial_t *obj);
+  static int _tx_complete_irq(serial_t *obj);
 
 #if defined(HAL_UART_MODULE_ENABLED) && !defined(HAL_UART_MODULE_ONLY)
-    // Could be used to mix Arduino API and AirCube HAL API (ex: DMA). Use at your own risk.
-    UART_HandleTypeDef *getHandle(void)
-    {
-      return &(_serial.handle);
-    }
+  // Could be used to mix Arduino API and AirCube HAL API (ex: DMA). Use at your own risk.
+  UART_HandleTypeDef *getHandle(void)
+  {
+    return &(_serial.handle);
+  }
 #endif // HAL_UART_MODULE_ENABLED && !HAL_UART_MODULE_ONLY
 
-  private:
-    bool _rx_enabled;
-    uint8_t _config;
-    unsigned long _baud;
-    void init(PinName _rx, PinName _tx, PinName _rts = NC, PinName _cts = NC);
-    void configForLowPower(void);
+private:
+  bool _rx_enabled;
+  uint8_t _config;
+  unsigned long _baud;
+  void init(PinName _rx, PinName _tx, PinName _rts = NC, PinName _cts = NC);
+  void configForLowPower(void);
 };
 
 #if defined(USART1)
-  extern HardwareSerial Serial1;
+extern HardwareSerial Serial1;
 #endif
 #if defined(USART2)
-  extern HardwareSerial Serial2;
+extern HardwareSerial Serial2;
 #endif
 #if defined(USART3)
-  extern HardwareSerial Serial3;
+extern HardwareSerial Serial3;
 #endif
 #if defined(UART4) || defined(USART4)
-  extern HardwareSerial Serial4;
+extern HardwareSerial Serial4;
 #endif
 #if defined(UART5) || defined(USART5)
-  extern HardwareSerial Serial5;
+extern HardwareSerial Serial5;
 #endif
 #if defined(USART6)
-  extern HardwareSerial Serial6;
+extern HardwareSerial Serial6;
 #endif
 #if defined(UART7) || defined(USART7)
-  extern HardwareSerial Serial7;
+extern HardwareSerial Serial7;
 #endif
 #if defined(UART8) || defined(USART8)
-  extern HardwareSerial Serial8;
+extern HardwareSerial Serial8;
 #endif
 #if defined(UART9)
-  extern HardwareSerial Serial9;
+extern HardwareSerial Serial9;
 #endif
 #if defined(UART10) || defined(USART10)
-  extern HardwareSerial Serial10;
+extern HardwareSerial Serial10;
 #endif
 #if defined(LPUART1)
-  extern HardwareSerial SerialLP1;
+extern HardwareSerial SerialLP1;
 #endif
 #if defined(LPUART2)
-  extern HardwareSerial SerialLP2;
+extern HardwareSerial SerialLP2;
 #endif
 #endif

--- a/cores/AirMCU/air/pinmap.h
+++ b/cores/AirMCU/air/pinmap.h
@@ -52,8 +52,11 @@ static inline PinName pin_pinName(const PinMap *map)
 }
 
 void  pinmap_pinout(PinName pin, const PinMap *map);
+void  pinmap_pinout_ignore(PinName pin, const PinMap *map, int ignore);
+void  pinmap_pinout_peripheral(PinName pin, const PinMap *map, void *peripheral);
 void *pinmap_find_peripheral(PinName pin, const PinMap *map);
 void *pinmap_peripheral(PinName pin, const PinMap *map);
+void *pinmap_peripheral_ignore(PinName pin, const PinMap *map,int ignore);
 PinName pinmap_find_pin(void *peripheral, const PinMap *map);
 PinName pinmap_pin(void *peripheral, const PinMap *map);
 uint32_t pinmap_find_function(PinName pin, const PinMap *map);

--- a/libraries/SrcWrapper/src/air/pinmap.c
+++ b/libraries/SrcWrapper/src/air/pinmap.c
@@ -2,12 +2,14 @@
 #include "pinconfig.h"
 #include "airyyxx_ll_gpio.h"
 #include "airyyxx_ll_system.h"
+#include <stdarg.h>
 
 #if defined(AIRMP1xx)
-  #include "lock_resource.h"
+#include "lock_resource.h"
 #endif
 
-typedef struct {
+typedef struct
+{
   PinName pin;
   uint32_t LL_AnalogSwitch;
 } PinAnalogSwitch;
@@ -15,12 +17,11 @@ typedef struct {
 #if defined(AIRH7xx)
 #define DUALPAD_ANALOG_SWITCH
 const PinAnalogSwitch PinMapAnalogSwitch[] = {
-  {PA_0,     LL_SYSCFG_ANALOG_SWITCH_PA0},
-  {PA_1,     LL_SYSCFG_ANALOG_SWITCH_PA1},
-  {PC_2,     LL_SYSCFG_ANALOG_SWITCH_PC2},
-  {PC_3,     LL_SYSCFG_ANALOG_SWITCH_PC3},
-  {NC,   0}
-};
+    {PA_0, LL_SYSCFG_ANALOG_SWITCH_PA0},
+    {PA_1, LL_SYSCFG_ANALOG_SWITCH_PA1},
+    {PC_2, LL_SYSCFG_ANALOG_SWITCH_PC2},
+    {PC_3, LL_SYSCFG_ANALOG_SWITCH_PC3},
+    {NC, 0}};
 #else
 /**
  * Even if MP1 support some dual pad (analog switch), we don't consider it
@@ -31,23 +32,22 @@ const PinAnalogSwitch PinMapAnalogSwitch[] = {
 
 /* Map AIR_PIN to LL */
 const uint32_t pin_map_ll[16] = {
-  LL_GPIO_PIN_0,
-  LL_GPIO_PIN_1,
-  LL_GPIO_PIN_2,
-  LL_GPIO_PIN_3,
-  LL_GPIO_PIN_4,
-  LL_GPIO_PIN_5,
-  LL_GPIO_PIN_6,
-  LL_GPIO_PIN_7,
-  LL_GPIO_PIN_8,
-  LL_GPIO_PIN_9,
-  LL_GPIO_PIN_10,
-  LL_GPIO_PIN_11,
-  LL_GPIO_PIN_12,
-  LL_GPIO_PIN_13,
-  LL_GPIO_PIN_14,
-  LL_GPIO_PIN_15
-};
+    LL_GPIO_PIN_0,
+    LL_GPIO_PIN_1,
+    LL_GPIO_PIN_2,
+    LL_GPIO_PIN_3,
+    LL_GPIO_PIN_4,
+    LL_GPIO_PIN_5,
+    LL_GPIO_PIN_6,
+    LL_GPIO_PIN_7,
+    LL_GPIO_PIN_8,
+    LL_GPIO_PIN_9,
+    LL_GPIO_PIN_10,
+    LL_GPIO_PIN_11,
+    LL_GPIO_PIN_12,
+    LL_GPIO_PIN_13,
+    LL_GPIO_PIN_14,
+    LL_GPIO_PIN_15};
 
 #if defined(DUALPAD_ANALOG_SWITCH)
 /**
@@ -56,27 +56,30 @@ const uint32_t pin_map_ll[16] = {
  */
 static void configure_dualpad_switch(PinName pin, int function, uint32_t LL_AnalogSwitch)
 {
-  if (LL_AnalogSwitch == 0) {
-    return ;
+  if (LL_AnalogSwitch == 0)
+  {
+    return;
   }
 
-  if (((function & AIR_MODE_ANALOG) != AIR_MODE_ANALOG)
-      && ((pin & PDUAL) == PDUAL)) {
+  if (((function & AIR_MODE_ANALOG) != AIR_MODE_ANALOG) && ((pin & PDUAL) == PDUAL))
+  {
     /**
-      * We don't configure an analog function but the pin is an analog pad
-      * Pxy_C. In this cases Analog switch should be closed
-      */
+     * We don't configure an analog function but the pin is an analog pad
+     * Pxy_C. In this cases Analog switch should be closed
+     */
     LL_SYSCFG_CloseAnalogSwitch(LL_AnalogSwitch);
-    return ;
-  } else {
+    return;
+  }
+  else
+  {
     /**
-      * Either we configure an analog function,
-      * or it is not an analog function but it is not an analog pad Pxy_C.
-      * In both cases Analog switch should be opened
-      * Note: direct ADC is restricted to Pxy_C,  pin only
-      */
+     * Either we configure an analog function,
+     * or it is not an analog function but it is not an analog pad Pxy_C.
+     * In both cases Analog switch should be opened
+     * Note: direct ADC is restricted to Pxy_C,  pin only
+     */
     LL_SYSCFG_OpenAnalogSwitch(LL_AnalogSwitch);
-    return ;
+    return;
   }
 }
 
@@ -88,25 +91,29 @@ static void configure_dualpad_switch(PinName pin, int function, uint32_t LL_Anal
  */
 static bool is_dualpad_switch_gpio_configurable(PinName pin, int function, uint32_t *pLL_AnalogSwitch)
 {
-  PinAnalogSwitch *AnalogSwitch = (PinAnalogSwitch *) PinMapAnalogSwitch;
+  PinAnalogSwitch *AnalogSwitch = (PinAnalogSwitch *)PinMapAnalogSwitch;
 
   /* Read through PinMapAnalogSwitch array */
-  while (AnalogSwitch->pin != NC) {
+  while (AnalogSwitch->pin != NC)
+  {
     /* Check whether pin is or is associated to dualpad Analog Input */
-    if ((AnalogSwitch->pin | PDUAL)  == (pin | PDUAL)) {
+    if ((AnalogSwitch->pin | PDUAL) == (pin | PDUAL))
+    {
       *pLL_AnalogSwitch = AnalogSwitch->LL_AnalogSwitch;
-      if (((function & AIR_MODE_ANALOG) == AIR_MODE_ANALOG)
-          && ((pin & PDUAL) == PDUAL)) {
+      if (((function & AIR_MODE_ANALOG) == AIR_MODE_ANALOG) && ((pin & PDUAL) == PDUAL))
+      {
         /**
          * We configure an analog function and the pin is an analog pad Pxy_C
          * In this case gpio configuration must be skipped
          */
         return false;
-      } else {
+      }
+      else
+      {
         return true;
       }
     }
-    AnalogSwitch ++;
+    AnalogSwitch++;
   }
   *pLL_AnalogSwitch = 0;
   return true;
@@ -115,9 +122,12 @@ static bool is_dualpad_switch_gpio_configurable(PinName pin, int function, uint3
 
 bool pin_in_pinmap(PinName pin, const PinMap *map)
 {
-  if (pin != (PinName)NC) {
-    while (map->pin != NC) {
-      if (map->pin == pin) {
+  if (pin != (PinName)NC)
+  {
+    while (map->pin != NC)
+    {
+      if (map->pin == pin)
+      {
         return true;
       }
       map++;
@@ -132,58 +142,64 @@ bool pin_in_pinmap(PinName pin, const PinMap *map)
 void pin_function(PinName pin, int function)
 {
   /* Get the pin information */
-  uint32_t mode  = AIR_PIN_FUNCTION(function);
+  uint32_t mode = AIR_PIN_FUNCTION(function);
   uint32_t afnum = AIR_PIN_AFNUM(function);
   uint32_t port = AIR_PORT(pin);
-  uint32_t ll_pin  = AIR_LL_GPIO_PIN(pin);
+  uint32_t ll_pin = AIR_LL_GPIO_PIN(pin);
   uint32_t ll_mode = 0;
 
-  if (pin == (PinName)NC) {
+  if (pin == (PinName)NC)
+  {
     Error_Handler();
   }
 
   /* Handle pin remap if any */
 #if defined(LL_SYSCFG_PIN_RMP_PA11) && defined(LL_SYSCFG_PIN_RMP_PA12) || defined(SYSCFG_CFGR1_PA11_PA12_RMP)
-  switch (pin & PNAME_MASK) {
+  switch (pin & PNAME_MASK)
+  {
 #if defined(SYSCFG_CFGR1_PA11_PA12_RMP)
-    /* Disable PIN pair PA11/12 mapped instead of PA9/10 */
-    case PA_9:
-    case PA_10:
-      LL_SYSCFG_DisablePinRemap();
-      break;
-    /* Enable PIN pair PA11/12 mapped instead of PA9/10 */
-    case PA_11:
-    case PA_12:
-      if ((pin & PREMAP) == PREMAP) {
-        LL_SYSCFG_EnablePinRemap();
-      }
-      break;
+  /* Disable PIN pair PA11/12 mapped instead of PA9/10 */
+  case PA_9:
+  case PA_10:
+    LL_SYSCFG_DisablePinRemap();
+    break;
+  /* Enable PIN pair PA11/12 mapped instead of PA9/10 */
+  case PA_11:
+  case PA_12:
+    if ((pin & PREMAP) == PREMAP)
+    {
+      LL_SYSCFG_EnablePinRemap();
+    }
+    break;
 #else
-    case PA_9:
-      if ((pin & PREMAP) == PREMAP) {
-        LL_SYSCFG_EnablePinRemap(LL_SYSCFG_PIN_RMP_PA11);
-      }
-      break;
-    case PA_10:
-      if ((pin & PREMAP) == PREMAP) {
-        LL_SYSCFG_EnablePinRemap(LL_SYSCFG_PIN_RMP_PA12);
-      }
-      break;
-    case PA_11:
-      LL_SYSCFG_DisablePinRemap(LL_SYSCFG_PIN_RMP_PA11);
-      break;
-    case PA_12:
-      LL_SYSCFG_DisablePinRemap(LL_SYSCFG_PIN_RMP_PA12);
-      break;
+  case PA_9:
+    if ((pin & PREMAP) == PREMAP)
+    {
+      LL_SYSCFG_EnablePinRemap(LL_SYSCFG_PIN_RMP_PA11);
+    }
+    break;
+  case PA_10:
+    if ((pin & PREMAP) == PREMAP)
+    {
+      LL_SYSCFG_EnablePinRemap(LL_SYSCFG_PIN_RMP_PA12);
+    }
+    break;
+  case PA_11:
+    LL_SYSCFG_DisablePinRemap(LL_SYSCFG_PIN_RMP_PA11);
+    break;
+  case PA_12:
+    LL_SYSCFG_DisablePinRemap(LL_SYSCFG_PIN_RMP_PA12);
+    break;
 #endif
-    default:
-      break;
+  default:
+    break;
   }
 #endif
 
 #if defined(DUALPAD_ANALOG_SWITCH)
   uint32_t LL_AnalogSwitch = 0;
-  if (!is_dualpad_switch_gpio_configurable(pin, function, &LL_AnalogSwitch)) {
+  if (!is_dualpad_switch_gpio_configurable(pin, function, &LL_AnalogSwitch))
+  {
     /* Skip gpio configuration */
     configure_dualpad_switch(pin, function, LL_AnalogSwitch);
     return;
@@ -200,58 +216,68 @@ void pin_function(PinName pin, int function)
    *  not so important, register can be set at any time.
    *  But for families like F1, speed only applies to output.
    */
-#if defined (AIR32F1xx)
-  if (mode == AIR_PIN_OUTPUT) {
+#if defined(AIR32F1xx)
+  if (mode == AIR_PIN_OUTPUT)
+  {
 #endif
 #ifdef LL_GPIO_SPEED_FREQ_VERY_HIGH
     LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
 #else
-    LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
+  LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
 #endif
-#if defined (AIR32F1xx)
+#if defined(AIR32F1xx)
   }
 #endif
 
-  switch (mode) {
-    case AIR_PIN_INPUT:
-      ll_mode = LL_GPIO_MODE_INPUT;
+  switch (mode)
+  {
+  case AIR_PIN_INPUT:
+    ll_mode = LL_GPIO_MODE_INPUT;
 #if defined(AIR32F1xx)
-      // on F1 family, input mode may be associated with an alternate function
-      pin_SetAFPin(gpio, pin, afnum);
+    // on F1 family, input mode may be associated with an alternate function
+    pin_SetAFPin(gpio, pin, afnum);
 #endif
-      break;
-    case AIR_PIN_OUTPUT:
-      ll_mode = LL_GPIO_MODE_OUTPUT;
-      break;
-    case AIR_PIN_ALTERNATE:
-      ll_mode = LL_GPIO_MODE_ALTERNATE;
-      /* In case of ALT function, also set the afnum */
-      if (afnum != AIR_PIN_AFNUM_MASK) {
-        pin_SetAFPin(gpio, pin, afnum);
-      }
-      break;
-    case AIR_PIN_ANALOG:
-      ll_mode = LL_GPIO_MODE_ANALOG;
-      break;
-    default:
-      Error_Handler();
-      break;
+    break;
+  case AIR_PIN_OUTPUT:
+    ll_mode = LL_GPIO_MODE_OUTPUT;
+    break;
+  case AIR_PIN_ALTERNATE:
+    ll_mode = LL_GPIO_MODE_ALTERNATE;
+    /* In case of ALT function, also set the afnum */
+    if (afnum != AIR_PIN_AFNUM_MASK)
+    {
+      pin_SetAFPin(gpio, pin, afnum);
+    }
+    break;
+  case AIR_PIN_ANALOG:
+    ll_mode = LL_GPIO_MODE_ANALOG;
+    break;
+  default:
+    Error_Handler();
+    break;
   }
   LL_GPIO_SetPinMode(gpio, ll_pin, ll_mode);
 
 #if defined(GPIO_ASCR_ASC0)
   /* For families where Analog Control ASC0 register is present */
-  if (AIR_PIN_ANALOG_CONTROL(function)) {
+  if (AIR_PIN_ANALOG_CONTROL(function))
+  {
     LL_GPIO_EnablePinAnalogControl(gpio, ll_pin);
-  } else {
+  }
+  else
+  {
     LL_GPIO_DisablePinAnalogControl(gpio, ll_pin);
   }
 #endif
 
-  if ((mode == AIR_PIN_OUTPUT) || (mode == AIR_PIN_ALTERNATE)) {
-    if (AIR_PIN_OD(function)) {
+  if ((mode == AIR_PIN_OUTPUT) || (mode == AIR_PIN_ALTERNATE))
+  {
+    if (AIR_PIN_OD(function))
+    {
       LL_GPIO_SetPinOutputType(gpio, ll_pin, LL_GPIO_OUTPUT_OPENDRAIN);
-    } else {
+    }
+    else
+    {
       LL_GPIO_SetPinOutputType(gpio, ll_pin, LL_GPIO_OUTPUT_PUSHPULL);
     }
   }
@@ -269,12 +295,15 @@ void pin_function(PinName pin, int function)
 
 void pinmap_pinout(PinName pin, const PinMap *map)
 {
-  if (pin == NC) {
+  if (pin == NC)
+  {
     return;
   }
 
-  while (map->pin != NC) {
-    if (map->pin == pin) {
+  while (map->pin != NC)
+  {
+    if (map->pin == pin)
+    {
       pin_function(pin, map->function);
       return;
     }
@@ -283,10 +312,58 @@ void pinmap_pinout(PinName pin, const PinMap *map)
   Error_Handler();
 }
 
+void  pinmap_pinout_ignore(PinName pin, const PinMap *map, int ignore)
+{
+  int count = 0;
+  if (pin == NC)
+  {
+    return;
+  }
+
+  while (map->pin != NC)
+  {
+    if (map->pin == pin)
+    {
+      if(count >= ignore)
+      {
+        pin_function(pin, map->function);
+        return;
+      }
+      count++;
+    }
+    map++;
+  }
+  Error_Handler();
+}
+
+void  pinmap_pinout_peripheral(PinName pin, const PinMap *map, void *peripheral)
+{
+  if (pin == NC)
+  {
+    return;
+  }
+
+  while (map->pin != NC)
+  {
+    if (map->pin == pin)
+    {
+      if (map->peripheral == peripheral)
+      {
+        pin_function(pin, map->function);
+        return;
+      }
+    }
+    map++;
+  }
+  Error_Handler();
+}
+
 void *pinmap_find_peripheral(PinName pin, const PinMap *map)
 {
-  while (map->pin != NC) {
-    if (map->pin == pin) {
+  while (map->pin != NC)
+  {
+    if (map->pin == pin)
+    {
       return map->peripheral;
     }
     map++;
@@ -298,16 +375,37 @@ void *pinmap_peripheral(PinName pin, const PinMap *map)
 {
   void *peripheral = NP;
 
-  if (pin != (PinName)NC) {
+  if (pin != (PinName)NC)
+  {
     peripheral = pinmap_find_peripheral(pin, map);
   }
   return peripheral;
 }
 
+void *pinmap_peripheral_ignore(PinName pin, const PinMap *map, int ignore)
+{
+  int count = 0;
+  while (map->pin != NC)
+  {
+    if (map->pin == pin)
+    {
+      if(count >= ignore)
+      {
+        return map->peripheral;
+      }
+      count++;
+    }
+    map++;
+  }
+  return NP;
+}
+
 PinName pinmap_find_pin(void *peripheral, const PinMap *map)
 {
-  while (map->peripheral != NP) {
-    if (map->peripheral == peripheral) {
+  while (map->peripheral != NP)
+  {
+    if (map->peripheral == peripheral)
+    {
       return map->pin;
     }
     map++;
@@ -319,7 +417,8 @@ PinName pinmap_pin(void *peripheral, const PinMap *map)
 {
   PinName pin = NC;
 
-  if (peripheral != NP) {
+  if (peripheral != NP)
+  {
     pin = pinmap_find_pin(peripheral, map);
   }
   return pin;
@@ -327,8 +426,10 @@ PinName pinmap_pin(void *peripheral, const PinMap *map)
 
 uint32_t pinmap_find_function(PinName pin, const PinMap *map)
 {
-  while (map->pin != NC) {
-    if (map->pin == pin) {
+  while (map->pin != NC)
+  {
+    if (map->pin == pin)
+    {
       return map->function;
     }
     map++;
@@ -340,7 +441,8 @@ uint32_t pinmap_function(PinName pin, const PinMap *map)
 {
   uint32_t function = (uint32_t)NC;
 
-  if (pin != (PinName)NC) {
+  if (pin != (PinName)NC)
+  {
     function = pinmap_find_function(pin, map);
   }
   return function;
@@ -350,15 +452,18 @@ uint32_t pinmap_function(PinName pin, const PinMap *map)
 void *pinmap_merge_peripheral(void *a, void *b)
 {
   // both are the same (inc both NP)
-  if (a == b) {
+  if (a == b)
+  {
     return a;
   }
 
   // one (or both) is not set
-  if (a == NP) {
+  if (a == NP)
+  {
     return b;
   }
-  if (b == NP) {
+  if (b == NP)
+  {
     return a;
   }
 

--- a/libraries/SrcWrapper/src/air/uart.c
+++ b/libraries/SrcWrapper/src/air/uart.c
@@ -147,15 +147,18 @@ void uart_init(serial_t *obj, uint32_t baudrate, uint32_t databits, uint32_t par
     }
     return;
   }
-
-  /*
-   * Get the peripheral name (USART1, USART2, ...) from the pin
-   * and assign it to the object
-   */
-  obj->uart = pinmap_merge_peripheral(uart_tx, uart_rx);
-  /* We also merge RTS/CTS and assert all pins belong to the same instance */
-  obj->uart = pinmap_merge_peripheral(obj->uart, uart_rts);
-  obj->uart = pinmap_merge_peripheral(obj->uart, uart_cts);
+  if(obj->uart == NP)
+  {
+    /*
+     * Get the peripheral name (USART1, USART2, ...) from the pin
+     * and assign it to the object
+     */
+    obj->uart = pinmap_merge_peripheral(uart_tx, uart_rx);
+    /* We also merge RTS/CTS and assert all pins belong to the same instance */
+    obj->uart = pinmap_merge_peripheral(obj->uart, uart_rts);
+    obj->uart = pinmap_merge_peripheral(obj->uart, uart_cts);
+  }
+  
 
   if (obj->uart == NP) {
     if (obj != &serial_debug) {
@@ -316,9 +319,13 @@ void uart_init(serial_t *obj, uint32_t baudrate, uint32_t databits, uint32_t par
 #endif
 
   /* Configure UART GPIO pins */
-  pinmap_pinout(obj->pin_tx, PinMap_UART_TX);
+  // pinmap_pinout(obj->pin_tx, PinMap_UART_TX);
+  // if (uart_rx != NP) {
+  //   pinmap_pinout(obj->pin_rx, PinMap_UART_RX);
+  // }
+  pinmap_pinout_peripheral(obj->pin_tx, PinMap_UART_TX, obj->uart);
   if (uart_rx != NP) {
-    pinmap_pinout(obj->pin_rx, PinMap_UART_RX);
+    pinmap_pinout_peripheral(obj->pin_rx, PinMap_UART_RX, obj->uart);
   }
 
   /* Configure flow control */


### PR DESCRIPTION
这是一个积压已久的问题，在 https://github.com/Air-duino/Arduino-AirMCU/issues/73 中有许多人抱怨无法正常启用在 Air001 上的第二个硬件串口。

经过仔细排查，发现在`pinmap_peripheral` `pinmap_pinout`等函数中，程序只会从pinmap数组中遍历查找，查找到第一个符合条件的即返回。而宏定义的作用则是帮我们实例化一个类，并没有指定其中某一个外设的作用。

详细的修改见commit，简而言之，我们在外设类中添加了一个静态的类似引用计数的东西来帮我们判断外设是否已经被初始化过了，如果已经进行了初始化，那我们将会去查找下一个。

最后，经过测试，两个硬件串口工作很完美

![fd24f4fc72c4cf0e29c3c70c5934ba2a](https://github.com/Air-duino/Arduino-AirMCU/assets/60973476/0076fac1-f898-4b32-ba1b-a7ee0a485ab4)

```cpp
#include <Arduino.h>
#include <HardwareSerial.h>

HardwareSerial mySerial(PF0, PA7);

void setup()
{
  Serial.begin(115200);
  mySerial.begin(115200);
}

void loop()
{
  Serial.println("Serial/Serial1");
  mySerial.println("Serial2");

  delay(1000);
}

```