### PR TITLE
fix: 修复Windows下build_opt.h中末尾没有空格可能会报错的问题

### DIFF
--- a/system/extras/prebuild.bat
+++ b/system/extras/prebuild.bat
@@ -5,9 +5,10 @@ set BOARD_PLATFORM_PATH=%3
 
 if not exist "%BUILD_PATH%\sketch" mkdir "%BUILD_PATH%\sketch"
 if not exist "%BUILD_SOURCE_PATH%\build_opt.h" (
-  echo -e "-fmacro-prefix-map=\"%BOARD_PLATFORM_PATH:\=\\%\"=." > "%BUILD_PATH%\sketch\build.opt"
+  echo "\n-fmacro-prefix-map=\"%BOARD_PLATFORM_PATH:\=\\%\"=." > "%BUILD_PATH%\sketch\build.opt"
 ) else (
   copy "%BUILD_SOURCE_PATH%\build_opt.h" "%BUILD_PATH%\sketch\build.opt"
-  echo -e "-fmacro-prefix-map=\"%BOARD_PLATFORM_PATH:\=\\%\"=." >> "%BUILD_PATH%\sketch\build.opt"
+  echo. >> "%BUILD_PATH%\sketch\build.opt"
+  echo "-fmacro-prefix-map=\"%BOARD_PLATFORM_PATH:\=\\%\"=." >> "%BUILD_PATH%\sketch\build.opt"
 )
 echo #include ^<SrcWrapper.h^> > "%BUILD_PATH%\sketch\SrcWrapper.cpp"


### PR DESCRIPTION
link https://github.com/Air-duino/Arduino-AirMCU/issues/83