### PR TITLE
增加air001xx_hal_conf_default.h下的HSE_STARTUP_TIMEOUT时间

### DIFF
--- a/system/AIR001xx/air001xx_hal_conf_default.h
+++ b/system/AIR001xx/air001xx_hal_conf_default.h
@@ -83,7 +83,7 @@ extern "C" {
   *        Timeout value
   */
 #if !defined  (HSE_STARTUP_TIMEOUT)
-#define HSE_STARTUP_TIMEOUT  100U      /*!< Time out for HSE start up, in ms */
+#define HSE_STARTUP_TIMEOUT  200U      /*!< Time out for HSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
 /**


### PR DESCRIPTION
实测Air001在24MHz外部晶振的情况下，HSE启动时间大于100ms，将HSE_STARTUP_TIMEOUT修改为200能够正常启动