### PR TITLE
Fix: 将源文件名从大写改为小写

### DIFF
--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal.c"
+  #include "air32f1xx_hal.c"
 #elif AIRF2xx
   #include "airf2xx_hal.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_adc.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_adc.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_adc.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_adc.c"
+  #include "air32f1xx_hal_adc.c"
 #elif AIRF2xx
   #include "airf2xx_hal_adc.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_adc_ex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_adc_ex.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_hal_adc_ex.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_adc_ex.c"
+  #include "air32f1xx_hal_adc_ex.c"
 #elif AIRF2xx
   #include "airf2xx_hal_adc_ex.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_can.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_can.c
@@ -6,8 +6,8 @@
   #include "Legacy/air001xx_hal_can.c"
   #include "air001xx_hal_can.c"
 #elif AIR32F1xx
-  #include "Legacy/AIR32F1xx_hal_can.c"
-  #include "AIR32F1xx_hal_can.c"
+  #include "Legacy/air32f1xx_hal_can.c"
+  #include "air32f1xx_hal_can.c"
 #elif AIRF2xx
   #include "Legacy/airf2xx_hal_can.c"
   #include "airf2xx_hal_can.c"

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_cec.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_cec.c
@@ -5,7 +5,7 @@
 #ifdef AIR001xx
   #include "air001xx_hal_cec.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_cec.c"
+  #include "air32f1xx_hal_cec.c"
 #elif AIRF3xx
   #include "airf3xx_hal_cec.c"
 #elif AIRF4xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_cortex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_cortex.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_cortex.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_cortex.c"
+  #include "air32f1xx_hal_cortex.c"
 #elif AIRF2xx
   #include "airf2xx_hal_cortex.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_crc.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_crc.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_crc.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_crc.c"
+  #include "air32f1xx_hal_crc.c"
 #elif AIRF2xx
   #include "airf2xx_hal_crc.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_dac.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_dac.c
@@ -5,7 +5,7 @@
 #ifdef AIR001xx
   #include "air001xx_hal_dac.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_dac.c"
+  #include "air32f1xx_hal_dac.c"
 #elif AIRF2xx
   #include "airf2xx_hal_dac.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_dac_ex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_dac_ex.c
@@ -5,7 +5,7 @@
 #ifdef AIR001xx
   #include "air001xx_hal_dac_ex.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_dac_ex.c"
+  #include "air32f1xx_hal_dac_ex.c"
 #elif AIRF2xx
   #include "airf2xx_hal_dac_ex.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_dma.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_dma.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_hal_dma.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_dma.c"
+  #include "air32f1xx_hal_dma.c"
 #elif AIRF2xx
   #include "airf2xx_hal_dma.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_eth.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_eth.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_eth.c"
+  #include "air32f1xx_hal_eth.c"
 #elif AIRF2xx
   #include "airf2xx_hal_eth.c"
 #elif AIRF4xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_exti.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_exti.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_exti.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_exti.c"
+  #include "air32f1xx_hal_exti.c"
 #elif AIRF2xx
   #include "airf2xx_hal_exti.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_flash.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_flash.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_flash.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_flash.c"
+  #include "air32f1xx_hal_flash.c"
 #elif AIRF2xx
   #include "airf2xx_hal_flash.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_flash_ex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_flash_ex.c
@@ -5,7 +5,7 @@
 #ifdef AIRC0xx
   #include "airc0xx_hal_flash_ex.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_flash_ex.c"
+  #include "air32f1xx_hal_flash_ex.c"
 #elif AIRF2xx
   #include "airf2xx_hal_flash_ex.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_gpio.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_gpio.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_gpio.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_gpio.c"
+  #include "air32f1xx_hal_gpio.c"
 #elif AIRF2xx
   #include "airf2xx_hal_gpio.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_gpio_ex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_gpio_ex.c
@@ -3,6 +3,6 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_gpio_ex.c"
+  #include "air32f1xx_hal_gpio_ex.c"
 #endif
 #pragma GCC diagnostic pop

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_hcd.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_hcd.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_hcd.c"
+  #include "air32f1xx_hal_hcd.c"
 #elif AIRF2xx
   #include "airf2xx_hal_hcd.c"
 #elif AIRF4xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_i2c.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_i2c.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_i2c.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_i2c.c"
+  #include "air32f1xx_hal_i2c.c"
 #elif AIRF2xx
   #include "airf2xx_hal_i2c.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_i2s.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_i2s.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_hal_i2s.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_i2s.c"
+  #include "air32f1xx_hal_i2s.c"
 #elif AIRF2xx
   #include "airf2xx_hal_i2s.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_irda.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_irda.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_hal_irda.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_irda.c"
+  #include "air32f1xx_hal_irda.c"
 #elif AIRF2xx
   #include "airf2xx_hal_irda.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_iwdg.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_iwdg.c
@@ -9,7 +9,7 @@
 #elif AIR401xx 
   #include "air401xx_hal_iwdg.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_iwdg.c"
+  #include "air32f1xx_hal_iwdg.c"
 #elif AIRF2xx
   #include "airf2xx_hal_iwdg.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_mmc.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_mmc.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_mmc.c"
+  #include "air32f1xx_hal_mmc.c"
 #elif AIRF2xx
   #include "airf2xx_hal_mmc.c"
 #elif AIRF4xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_nand.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_nand.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_nand.c"
+  #include "air32f1xx_hal_nand.c"
 #elif AIRF2xx
   #include "airf2xx_hal_nand.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_nor.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_nor.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_nor.c"
+  #include "air32f1xx_hal_nor.c"
 #elif AIRF2xx
   #include "airf2xx_hal_nor.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_pccard.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_pccard.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_pccard.c"
+  #include "air32f1xx_hal_pccard.c"
 #elif AIRF2xx
   #include "airf2xx_hal_pccard.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_pcd.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_pcd.c
@@ -5,7 +5,7 @@
 #ifdef AIR001xx
   #include "air001xx_hal_pcd.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_pcd.c"
+  #include "air32f1xx_hal_pcd.c"
 #elif AIRF2xx
   #include "airf2xx_hal_pcd.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_pcd_ex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_pcd_ex.c
@@ -5,7 +5,7 @@
 #ifdef AIR001xx
   #include "air001xx_hal_pcd_ex.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_pcd_ex.c"
+  #include "air32f1xx_hal_pcd_ex.c"
 #elif AIRF2xx
   #include "airf2xx_hal_pcd_ex.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_pwr.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_pwr.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_pwr.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_pwr.c"
+  #include "air32f1xx_hal_pwr.c"
 #elif AIRF2xx
   #include "airf2xx_hal_pwr.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_rcc.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_rcc.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_rcc.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_rcc.c"
+  #include "air32f1xx_hal_rcc.c"
 #elif AIRF2xx
   #include "airf2xx_hal_rcc.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_rcc_ex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_rcc_ex.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_rcc_ex.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_rcc_ex.c"
+  #include "air32f1xx_hal_rcc_ex.c"
 #elif AIRF2xx
   #include "airf2xx_hal_rcc_ex.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_rtc.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_rtc.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_hal_rtc.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_rtc.c"
+  #include "air32f1xx_hal_rtc.c"
 #elif AIRF2xx
   #include "airf2xx_hal_rtc.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_rtc_ex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_rtc_ex.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_hal_rtc_ex.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_rtc_ex.c"
+  #include "air32f1xx_hal_rtc_ex.c"
 #elif AIRF2xx
   #include "airf2xx_hal_rtc_ex.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_sd.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_sd.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_sd.c"
+  #include "air32f1xx_hal_sd.c"
 #elif AIRF2xx
   #include "airf2xx_hal_sd.c"
 #elif AIRF4xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_smartcard.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_smartcard.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_hal_smartcard.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_smartcard.c"
+  #include "air32f1xx_hal_smartcard.c"
 #elif AIRF2xx
   #include "airf2xx_hal_smartcard.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_spi.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_spi.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_spi.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_spi.c"
+  #include "air32f1xx_hal_spi.c"
 #elif AIRF2xx
   #include "airf2xx_hal_spi.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_sram.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_sram.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_hal_sram.c"
+  #include "air32f1xx_hal_sram.c"
 #elif AIRF2xx
   #include "airf2xx_hal_sram.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_tim.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_tim.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_tim.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_tim.c"
+  #include "air32f1xx_hal_tim.c"
 #elif AIRF2xx
   #include "airf2xx_hal_tim.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_tim_ex.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_tim_ex.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_tim_ex.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_tim_ex.c"
+  #include "air32f1xx_hal_tim_ex.c"
 #elif AIRF2xx
   #include "airf2xx_hal_tim_ex.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_uart.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_uart.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_uart.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_uart.c"
+  #include "air32f1xx_hal_uart.c"
 #elif AIRF2xx
   #include "airf2xx_hal_uart.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_usart.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_usart.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_hal_usart.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_usart.c"
+  #include "air32f1xx_hal_usart.c"
 #elif AIRF2xx
   #include "airf2xx_hal_usart.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/HAL/airyyxx_hal_wwdg.c
+++ b/libraries/SrcWrapper/src/HAL/airyyxx_hal_wwdg.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_hal_wwdg.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_hal_wwdg.c"
+  #include "air32f1xx_hal_wwdg.c"
 #elif AIRF2xx
   #include "airf2xx_hal_wwdg.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_adc.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_adc.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_adc.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_adc.c"
+  #include "air32f1xx_ll_adc.c"
 #elif AIRF2xx
   #include "airf2xx_ll_adc.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_crc.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_crc.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_crc.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_crc.c"
+  #include "air32f1xx_ll_crc.c"
 #elif AIRF2xx
   #include "airf2xx_ll_crc.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_dac.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_dac.c
@@ -5,7 +5,7 @@
 #ifdef AIR001xx
   #include "air001xx_ll_dac.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_dac.c"
+  #include "air32f1xx_ll_dac.c"
 #elif AIRF2xx
   #include "airf2xx_ll_dac.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_dma.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_dma.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_ll_dma.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_dma.c"
+  #include "air32f1xx_ll_dma.c"
 #elif AIRF2xx
   #include "airf2xx_ll_dma.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_exti.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_exti.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_exti.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_exti.c"
+  #include "air32f1xx_ll_exti.c"
 #elif AIRF2xx
   #include "airf2xx_ll_exti.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_fsmc.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_fsmc.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_ll_fsmc.c"
+  #include "air32f1xx_ll_fsmc.c"
 #elif AIRF2xx
   #include "airf2xx_ll_fsmc.c"
 #elif AIRF4xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_gpio.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_gpio.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_gpio.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_gpio.c"
+  #include "air32f1xx_ll_gpio.c"
 #elif AIRF2xx
   #include "airf2xx_ll_gpio.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_i2c.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_i2c.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_i2c.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_i2c.c"
+  #include "air32f1xx_ll_i2c.c"
 #elif AIRF2xx
   #include "airf2xx_ll_i2c.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_pwr.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_pwr.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_pwr.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_pwr.c"
+  #include "air32f1xx_ll_pwr.c"
 #elif AIRF2xx
   #include "airf2xx_ll_pwr.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_rcc.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_rcc.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_rcc.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_rcc.c"
+  #include "air32f1xx_ll_rcc.c"
 #elif AIRF2xx
   #include "airf2xx_ll_rcc.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_rtc.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_rtc.c
@@ -7,7 +7,7 @@
 #elif AIR001xx
   #include "air001xx_ll_rtc.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_rtc.c"
+  #include "air32f1xx_ll_rtc.c"
 #elif AIRF2xx
   #include "airf2xx_ll_rtc.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_sdmmc.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_sdmmc.c
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifdef AIR32F1xx
-  #include "AIR32F1xx_ll_sdmmc.c"
+  #include "air32f1xx_ll_sdmmc.c"
 #elif AIRF2xx
   #include "airf2xx_ll_sdmmc.c"
 #elif AIRF4xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_spi.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_spi.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_spi.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_spi.c"
+  #include "air32f1xx_ll_spi.c"
 #elif AIRF2xx
   #include "airf2xx_ll_spi.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_tim.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_tim.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_tim.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_tim.c"
+  #include "air32f1xx_ll_tim.c"
 #elif AIRF2xx
   #include "airf2xx_ll_tim.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_usart.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_usart.c
@@ -9,7 +9,7 @@
 #elif AIR401xx 
   #include "air401xx_ll_usart.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_usart.c"
+  #include "air32f1xx_ll_usart.c"
 #elif AIRF2xx
   #include "airf2xx_ll_usart.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_usb.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_usb.c
@@ -5,7 +5,7 @@
 #ifdef AIR001xx
   #include "air001xx_ll_usb.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_usb.c"
+  #include "air32f1xx_ll_usb.c"
 #elif AIRF2xx
   #include "airf2xx_ll_usb.c"
 #elif AIRF3xx

--- a/libraries/SrcWrapper/src/LL/airyyxx_ll_utils.c
+++ b/libraries/SrcWrapper/src/LL/airyyxx_ll_utils.c
@@ -9,7 +9,7 @@
 #elif AIR401xx
   #include "air401xx_ll_utils.c"
 #elif AIR32F1xx
-  #include "AIR32F1xx_ll_utils.c"
+  #include "air32f1xx_ll_utils.c"
 #elif AIRF2xx
   #include "airf2xx_ll_utils.c"
 #elif AIRF3xx


### PR DESCRIPTION
Linux 文件名区分大小写，如果不更改，就无法编译